### PR TITLE
Add MultivariatePolynomials support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [compat]
 julia = "1"
 
+[extensions]
+VectorInterfaceMultivariatePolynomialsExt = "MultivariatePolynomials"
+
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -16,3 +19,6 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 
 [targets]
 test = ["Test", "TestExtras", "Aqua"]
+
+[weakdeps]
+MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"

--- a/ext/VectorInterfaceMultivariatePolynomialsExt.jl
+++ b/ext/VectorInterfaceMultivariatePolynomialsExt.jl
@@ -1,0 +1,18 @@
+module VectorInterfaceMultivariatePolynomialsExt
+
+import VectorInterface
+using MultivariatePolynomials
+
+# union of all abstract types that can be crudely supported?
+const PolyTypes = Union{<:AbstractPolynomialLike, <:AbstractTermLike, <:AbstractMonomialLike}
+
+# not clear if this is really the true `scalartype` we want
+VectorInterface.scalartype(T::Type{<:PolyTypes}) = T
+
+function VectorInterface.add!!(w::PolyTypes, v::PolyTypes, α::Number, β::Number)
+    return w * β + v * α
+end
+
+VectorInterface.scale!!(v::PolyTypes, α::Number) = v * α
+
+end


### PR DESCRIPTION
Adds the minimal interface needed for polynomials to function with TensorOperations.
This is done via a package extension, such as to not create additional dependencies.