### PR TITLE
`scale!!(y, x, a)` considers scalartype of `y` for determining result type 

### DIFF
--- a/src/VectorInterface.jl
+++ b/src/VectorInterface.jl
@@ -19,7 +19,9 @@ include("onezero.jl")
 promote_scale(x, α::Number) = promote_scale(scalartype(x), typeof(α))
 promote_scale(::Type{Tx}, ::Type{Tα}) where {Tx,Tα<:Number} = Base.promote_op(scale, Tx, Tα)
 promote_scale(x, y, α::Number) = promote_scale(scalartype(x), scalartype(y), typeof(α))
-promote_scale(::Type{Tx}, ::Type{Ty}, ::Type{Tα}) where {Tx,Ty,Tα<:Number} = Base.promote_op(scale, Tx, Ty, Tα)
+function promote_scale(::Type{Tx}, ::Type{Ty}, ::Type{Tα}) where {Tx,Ty,Tα<:Number}
+    return Base.promote_op(scale, Tx, Ty, Tα)
+end
 
 function promote_add(x, y, α::Number=One(), β::Number=One())
     return promote_add(scalartype(x), scalartype(y), typeof(α), typeof(β))

--- a/src/VectorInterface.jl
+++ b/src/VectorInterface.jl
@@ -18,6 +18,8 @@ include("onezero.jl")
 # Auxiliary methods for determining types
 promote_scale(x, α::Number) = promote_scale(scalartype(x), typeof(α))
 promote_scale(::Type{Tx}, ::Type{Tα}) where {Tx,Tα<:Number} = Base.promote_op(scale, Tx, Tα)
+promote_scale(x, y, α::Number) = promote_scale(scalartype(x), scalartype(y), typeof(α))
+promote_scale(::Type{Tx}, ::Type{Ty}, ::Type{Tα}) where {Tx,Ty,Tα<:Number} = Base.promote_op(scale, Tx, Ty, Tα)
 
 function promote_add(x, y, α::Number=One(), β::Number=One())
     return promote_add(scalartype(x), scalartype(y), typeof(α), typeof(β))

--- a/src/abstractarray.jl
+++ b/src/abstractarray.jl
@@ -57,7 +57,7 @@ function scale!!(x::AbstractArray, α::Number)
     end
 end
 function scale!!(y::AbstractArray, x::AbstractArray, α::Number)
-    if promote_scale(x, α) <: scalartype(y)
+    if promote_scale(y, x, α) <: scalartype(y)
         return scale!(y, x, α)
     else
         return scale!!.(y, x, (α,))

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -112,12 +112,15 @@ end
 function scale!!(y, x, α::Number)
     T = Tuple{typeof(y),typeof(x),typeof(α)}
     @warn _warn_message(scale!!, T) maxlog = 1
-    if applicable(LinearAlgebra.mul!, y, x, α) && promote_scale(x, α) <: scalartype(y)
+    if applicable(LinearAlgebra.mul!, y, x, α) && promote_scale(y, x, α) <: scalartype(y)
         return LinearAlgebra.mul!(y, x, α)
-    elseif applicable(*, x, α)
-        return x * α
     else
-        throw(ArgumentError(_error_message(scale!!, T)))
+        α_Ty = α * one(scalartype(y))
+        if applicable(*, x, α_Ty)
+            return x * α_Ty
+        else
+            throw(ArgumentError(_error_message(scale!!, T)))
+        end
     end
 end
 

--- a/src/number.jl
+++ b/src/number.jl
@@ -14,8 +14,12 @@ scalartype(::Type{T}) where {T<:Number} = T
 #-----------------
 # note: required to make scale(NaN, 0) = 0
 @inline scale(x::Number, α::Number) = (iszero(α) ? zero(x) : x) * α
+@inline function scale(y::Number, x::Number, α::Number)
+    T = Base.promote_op(*, typeof(y), typeof(x), typeof(α))
+    return convert(T, scale(x, α))
+end
 @inline scale!!(x::Number, α::Number) = scale(x, α)
-@inline scale!!(y::Number, x::Number, α::Number) = scale(x, α)
+@inline scale!!(y::Number, x::Number, α::Number) = scale(y, x, α)
 
 # add & add!!
 #-------------

--- a/test/simple.jl
+++ b/test/simple.jl
@@ -75,7 +75,7 @@ end
     z7 = @constinferred scale!(xz, xcopy, α)
     @test deepcollect(z7) ≈ (α .* deepcollect(x))
     @test all(deepcollect(xcopy) .== deepcollect(x))
-    
+
     ycomplex = zerovector(y, ComplexF64)
     α = randn(Float64)
     xcopy = deepcopy(x)

--- a/test/simple.jl
+++ b/test/simple.jl
@@ -75,6 +75,13 @@ end
     z7 = @constinferred scale!(xz, xcopy, α)
     @test deepcollect(z7) ≈ (α .* deepcollect(x))
     @test all(deepcollect(xcopy) .== deepcollect(x))
+    
+    ycomplex = zerovector(y, ComplexF64)
+    α = randn(Float64)
+    xcopy = deepcopy(x)
+    z8 = @constinferred scale!!(ycomplex, xcopy, α)
+    @test z8 === ycomplex
+    @test all(deepcollect(z8) .== α .* deepcollect(xcopy))
 end
 
 @testset "add" begin


### PR DESCRIPTION
This fixes #10 .