### PR TITLE
Fix ambiguity for promoting `Bool`, `Zero` and `One`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VectorInterface"
 uuid = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 authors = ["Jutho Haegeman <jutho.haegeman@ugent.be> and contributors"]
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/onezero.jl
+++ b/src/onezero.jl
@@ -75,6 +75,9 @@ Base.promote_rule(::Type{Zero}, ::Type{One}) = Bool
 Base.promote_rule(::Type{One}, ::Type{Zero}) = Bool
 Base.promote_rule(::Type{One}, ::Type{T}) where {T<:Number} = T
 Base.promote_rule(::Type{Zero}, ::Type{T}) where {T<:Number} = T
+# disambiguate:
+Base.promote_rule(::Type{Bool}, ::Type{One}) = Bool
+Base.promote_rule(::Type{Bool}, ::Type{Zero}) = Bool
 Base.convert(::Type{T}, ::One) where {T<:Number} = one(T)
 (T::Type{<:Number})(::One) = one(T)
 Base.convert(::Type{T}, ::Zero) where {T<:Number} = zero(T)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1,12 +1,20 @@
-# came up here: https://github.com/Jutho/TensorOperations.jl/issues/154
 
 module Issues
 using VectorInterface
 using Test
 using TestExtras
 
-@test @constinferred zerovector(fill(0.5), Float32) isa Array{Float32,0}
-@test @constinferred scale(fill(0.5), 0.3) isa Array{Float64,0}
-@test @constinferred add(fill(0.5), fill(0.8), 0.3f0, 0.25im) isa Array{ComplexF64,0}
+# came up here: https://github.com/Jutho/TensorOperations.jl/issues/154
+@testset begin
+    @test @constinferred zerovector(fill(0.5), Float32) isa Array{Float32,0}
+    @test @constinferred scale(fill(0.5), 0.3) isa Array{Float64,0}
+    @test @constinferred add(fill(0.5), fill(0.8), 0.3f0, 0.25im) isa Array{ComplexF64,0}
+end
+
+# came up here: https://github.com/Jutho/VectorInterface.jl/issues/20
+@testset begin
+    @test promote_type(Bool, One) === promote_type(Bool, Zero) ===
+          promote_type(One, Bool) === promote_type(Zero, Bool) === Bool
+end
 
 end


### PR DESCRIPTION
Fixes #20 