### PR TITLE
Bump v0.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VectorInterface"
 uuid = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 authors = ["Jutho Haegeman <jutho.haegeman@ugent.be> and contributors"]
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Since this was originally not tagged, should not be increased here.

Release notes:

This release brings automatic differentiation support to VectorInterface via package
extensions for ChainRulesCore, Enzyme, and Mooncake, alongside a StaticArrays extension,
a new documentation site, and a modernized project layout.

### Highlights

- **Autodiff support via extensions**: forward and reverse rules for
  [ChainRulesCore](https://github.com/JuliaDiff/ChainRulesCore.jl) (#26),
  [Enzyme](https://github.com/EnzymeAD/Enzyme.jl) (#37), and
  [Mooncake](https://github.com/chalk-lab/Mooncake.jl) (#36, #38).
- **StaticArrays extension** for `SVector`/`MVector` (#39).
- **Documentation site** with interface reference and motivation pages (#40).
- **Modernized project structure**: workspace-based test environment, updated `[compat]`
  entries, minimum Julia 1.10 (#42).

### Full changelog

See https://github.com/QuantumKitHub/VectorInterface.jl/compare/v0.5.0...v0.6.0 for the
complete list of changes.
